### PR TITLE
Card som knapp directive og tester for den

### DIFF
--- a/e2e/components/card.spec.ts
+++ b/e2e/components/card.spec.ts
@@ -32,6 +32,19 @@ test.describe('Card', () => {
     await expect(section.locator('hvi-card a').first()).toBeVisible();
   });
 
+  test('card button section renders a button with ds-card class', async ({ page }) => {
+    const section = page.locator('app-demo-section[title="Card som er en knapp"]');
+    const button = section.locator('button.ds-card');
+    await expect(button).toBeVisible();
+  });
+
+  test('card button has hardcoded data-variant and data-color attributes', async ({ page }) => {
+    const section = page.locator('app-demo-section[title="Card som er en knapp"]');
+    const button = section.locator('button.ds-card');
+    await expect(button).toHaveAttribute('data-variant', 'default');
+    await expect(button).toHaveAttribute('data-color', 'neutral');
+  });
+
   test('accessibility check', async ({ page }) => {
     await checkAccessibility(page, ['color-contrast'], 'article');
   });

--- a/projects/hviktor/src/card/card-button.directive.spec.ts
+++ b/projects/hviktor/src/card/card-button.directive.spec.ts
@@ -1,0 +1,59 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { setupTestBed } from '../testing/test-utils';
+import { HviCardButton } from './card-button.directive';
+
+@Component({
+  standalone: true,
+  imports: [HviCardButton],
+  template: '<button hviCardButton>Click me</button>',
+})
+class DefaultCardButtonComponent {}
+
+@Component({
+  standalone: true,
+  imports: [HviCardButton],
+  template: '<button hviCardButton maxWidth="320px">Click me</button>',
+})
+class MaxWidthCardButtonComponent {}
+
+describe('HviCardButton', () => {
+  beforeEach(async () => {
+    await setupTestBed({ imports: [DefaultCardButtonComponent, MaxWidthCardButtonComponent] });
+  });
+
+  it('should add ds-card class to its host element', () => {
+    const f = TestBed.createComponent(DefaultCardButtonComponent);
+    f.detectChanges();
+    const button = f.nativeElement.querySelector('button');
+    expect(button.classList.contains('ds-card')).toBe(true);
+  });
+
+  it('should set data-variant to default', () => {
+    const f = TestBed.createComponent(DefaultCardButtonComponent);
+    f.detectChanges();
+    const button = f.nativeElement.querySelector('button');
+    expect(button.getAttribute('data-variant')).toBe('default');
+  });
+
+  it('should set data-color to neutral', () => {
+    const f = TestBed.createComponent(DefaultCardButtonComponent);
+    f.detectChanges();
+    const button = f.nativeElement.querySelector('button');
+    expect(button.getAttribute('data-color')).toBe('neutral');
+  });
+
+  it('should apply max-width style when maxWidth is set', () => {
+    const f = TestBed.createComponent(MaxWidthCardButtonComponent);
+    f.detectChanges();
+    const button = f.nativeElement.querySelector('button');
+    expect(button.style.maxWidth).toBe('320px');
+  });
+
+  it('should not apply max-width style when maxWidth is not set', () => {
+    const f = TestBed.createComponent(DefaultCardButtonComponent);
+    f.detectChanges();
+    const button = f.nativeElement.querySelector('button');
+    expect(button.style.maxWidth).toBe('');
+  });
+});

--- a/projects/hviktor/src/card/card-button.directive.ts
+++ b/projects/hviktor/src/card/card-button.directive.ts
@@ -1,0 +1,34 @@
+import { Directive, Input } from '@angular/core';
+
+/**
+ * @summary
+ * CardButton makes an entire card a clickable button. It applies the `ds-card`
+ * class with hardcoded `default` variant and `neutral` color. Use it when the
+ * card should trigger an action like opening a dialog rather than navigate via a link.
+ *
+ * @example Card button with content
+ * ```html
+ * <button hviCardButton maxWidth="420px">
+ *   <div hviCardBlock>
+ *     <h2 hviHeading>Innstillinger</h2>
+ *     <p hviParagraph>Åpne innstillinger og personvern.</p>
+ *   </div>
+ * </button>
+ * ```
+ *
+ * @see {@link https://designsystemet.no/en/components/docs/card/code/}
+ */
+@Directive({
+  selector: 'button[hviCardButton]',
+  standalone: true,
+  host: {
+    class: 'ds-card',
+    'data-variant': 'default',
+    'data-color': 'neutral',
+    '[style.max-width]': 'maxWidth',
+  },
+})
+export class HviCardButton {
+  /** Maximum width of the card (e.g. `'320px'` or `'20rem'`). */
+  @Input() maxWidth?: string;
+}

--- a/projects/hviktor/src/card/index.ts
+++ b/projects/hviktor/src/card/index.ts
@@ -1,2 +1,3 @@
 export { HviCardBlock } from './card-block.directive';
+export { HviCardButton } from './card-button.directive';
 export { HviCard } from './card.component';

--- a/src/app/demo/pages/components/card/card-demo.ts
+++ b/src/app/demo/pages/components/card/card-demo.ts
@@ -3,12 +3,14 @@ import {
   HviButton,
   HviCard,
   HviCardBlock,
+  HviCardButton,
   HviHeading,
   HviLink,
   HviParagraph,
 } from '@helsevestikt/hviktor';
 import { DemoPageComponent, DemoSectionComponent } from '../../../shared';
 
+import { CardCardSomErEnKnappExampleSource } from './code-examples/card.card-som-er-en-knapp.example.source';
 import { CardFargerOgVarianterExampleSource } from './code-examples/card.farger-og-varianter.example.source';
 import { CardLenkekortExampleSource } from './code-examples/card.lenkekort.example.source';
 import { CardMedInndelingExampleSource } from './code-examples/card.med-inndeling.example.source';
@@ -25,6 +27,7 @@ import { CardStandardExampleSource } from './code-examples/card.standard.example
     HviParagraph,
     DemoPageComponent,
     DemoSectionComponent,
+    HviCardButton,
   ],
   template: `
     <app-demo-page componentId="card">
@@ -112,10 +115,27 @@ import { CardStandardExampleSource } from './code-examples/card.standard.example
           </hvi-card>
         </div>
       </app-demo-section>
+
+      <app-demo-section title="Card som er en knapp" [code]="cardSomErEnKnappCode">
+        <div class="flex flex-wrap gap-4">
+          <button hviCardButton maxWidth="420px">
+            <div hviCardBlock>
+              <h2 hviHeading>Innstillinger og personvern</h2>
+              <p hviParagraph>
+                Dette åpner en dialog der du kan oppdatere personvernvalg, justere innstillinger og
+                tilpasse hvordan tjenesten behandler informasjonen din. Du kan se gjennom endringene
+                før du lagrer.
+              </p>
+              <p hviParagraph size="sm">Innstillinger og personvern</p>
+            </div>
+          </button>
+        </div>
+      </app-demo-section>
     </app-demo-page>
   `,
 })
 export class CardDemoComponent {
+  readonly cardSomErEnKnappCode = CardCardSomErEnKnappExampleSource;
   readonly standardCode = CardStandardExampleSource;
   readonly fargerOgVarianterCode = CardFargerOgVarianterExampleSource;
   readonly medInndelingCode = CardMedInndelingExampleSource;

--- a/src/app/demo/pages/components/card/code-examples/card.card-som-er-en-knapp.example.source.ts
+++ b/src/app/demo/pages/components/card/code-examples/card.card-som-er-en-knapp.example.source.ts
@@ -1,0 +1,28 @@
+// Auto-generated - do not edit manually
+export const CardCardSomErEnKnappExampleSource = `import { Component } from '@angular/core';
+import { HviCard, HviCardBlock, HviCardButton, HviHeading, HviParagraph } from '@helsevestikt/hviktor';
+
+@Component({
+  selector: 'app-card-card-som-er-en-knapp-example',
+  standalone: true,
+  imports: [HviCardBlock, HviCardButton, HviHeading, HviParagraph],
+  template: \`
+    <div class="flex flex-wrap gap-4">
+      <button hviCardButton maxWidth="420px">
+        <div hviCardBlock>
+          <h2 hviHeading>Innstillinger og personvern</h2>
+          <p hviParagraph>
+            Dette åpner en dialog der du kan oppdatere personvernvalg, justere innstillinger og
+            tilpasse hvordan tjenesten behandler informasjonen din. Du kan se gjennom endringene
+            før du lagrer.
+          </p>
+          <p hviParagraph size="sm">Innstillinger og personvern</p>
+        </div>
+      </button>
+    </div>
+  \`,
+})
+export class CardCardSomErEnKnappExampleComponent {
+  
+}
+`;

--- a/src/app/demo/pages/components/card/code-examples/card.card-som-er-en-knapp.example.ts
+++ b/src/app/demo/pages/components/card/code-examples/card.card-som-er-en-knapp.example.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { HviCardBlock, HviCardButton, HviHeading, HviParagraph } from '@helsevestikt/hviktor';
+
+@Component({
+  selector: 'app-card-card-som-er-en-knapp-example',
+  standalone: true,
+  imports: [HviCardBlock, HviCardButton, HviHeading, HviParagraph],
+  template: `
+    <div class="flex flex-wrap gap-4">
+      <button hviCardButton maxWidth="420px">
+        <div hviCardBlock>
+          <h2 hviHeading>Innstillinger og personvern</h2>
+          <p hviParagraph>
+            Dette åpner en dialog der du kan oppdatere personvernvalg, justere innstillinger og
+            tilpasse hvordan tjenesten behandler informasjonen din. Du kan se gjennom endringene før
+            du lagrer.
+          </p>
+          <p hviParagraph size="sm">Innstillinger og personvern</p>
+        </div>
+      </button>
+    </div>
+  `,
+})
+export class CardCardSomErEnKnappExampleComponent {}

--- a/src/app/demo/pages/components/card/code-examples/index.ts
+++ b/src/app/demo/pages/components/card/code-examples/index.ts
@@ -1,4 +1,6 @@
 // Auto-generated - do not edit manually
+export * from './card.card-som-er-en-knapp.example';
+export * from './card.card-som-er-en-knapp.example.source';
 export * from './card.farger-og-varianter.example';
 export * from './card.farger-og-varianter.example.source';
 export * from './card.lenkekort.example';

--- a/src/app/demo/pages/components/card/code-examples/manifest.ts
+++ b/src/app/demo/pages/components/card/code-examples/manifest.ts
@@ -24,6 +24,17 @@ export const CardExamplesManifest = [
     className: 'CardLenkekortExampleComponent',
     sourceExport: 'CardLenkekortExampleSource',
   },
+  {
+    slug: 'card-som-er-en-knapp',
+    title: 'Card som er en knapp',
+    className: 'CardCardSomErEnKnappExampleComponent',
+    sourceExport: 'CardCardSomErEnKnappExampleSource',
+  },
 ] as const;
 
-export type CardExampleSlug = 'standard' | 'farger-og-varianter' | 'med-inndeling' | 'lenkekort';
+export type CardExampleSlug =
+  | 'standard'
+  | 'farger-og-varianter'
+  | 'med-inndeling'
+  | 'lenkekort'
+  | 'card-som-er-en-knapp';


### PR DESCRIPTION
Card som knapp er lagt til for Card. Laget card-button som et direktiv som da bruker button[HviCardButton]. Da er det button som må brukes, og klassen ds-card er lagt på den. Satt variant og color som standard default og neutral, siden de alltid skal være det i et card som knapp. Da slipper også utviklerne å skrive det inn når de bruker den.
La til tester og kodeeksempel for card-button
#257
