### PR TITLE
AvatarStack UU forbedringer

### DIFF
--- a/e2e/components/avatar-stack.spec.ts
+++ b/e2e/components/avatar-stack.spec.ts
@@ -26,6 +26,12 @@ test.describe('AvatarStack', () => {
     await expect(section.locator('hvi-avatar-stack[data-expandable="true"]')).toBeVisible();
   });
 
+  test('has aria-label on avatar stack', async ({ page }) => {
+    const section = page.locator('app-demo-section[title="Standard Avatar Stack"]');
+    const stack = section.locator('hvi-avatar-stack');
+    await expect(stack).toHaveAttribute('aria-label', 'Topp 3 ansatte i bedriften');
+  });
+
   test('accessibility check', async ({ page }) => {
     await checkAccessibility(page, ['color-contrast'], 'article');
   });

--- a/projects/hviktor/src/avatar-stack/avatar-stack.component.spec.ts
+++ b/projects/hviktor/src/avatar-stack/avatar-stack.component.spec.ts
@@ -45,6 +45,17 @@ class StackExpandableComponent {}
 })
 class StackSquareVariantComponent {}
 
+@Component({
+  standalone: true,
+  imports: [HviAvatarStack, HviAvatar],
+  template: `
+    <hvi-avatar-stack aria-label="Teammedlemmer">
+      <hvi-avatar aria-label="Ola" initials="ON"></hvi-avatar>
+    </hvi-avatar-stack>
+  `,
+})
+class StackCustomAriaLabelComponent {}
+
 describe('HviAvatarStack', () => {
   beforeEach(async () => {
     await setupTestBed({
@@ -53,6 +64,7 @@ describe('HviAvatarStack', () => {
         StackSquareVariantComponent,
         StackWithSuffixComponent,
         StackExpandableComponent,
+        StackCustomAriaLabelComponent,
       ],
     });
   });
@@ -101,6 +113,22 @@ describe('HviAvatarStack', () => {
     const f = TestBed.createComponent(BasicStackComponent);
     f.detectChanges();
     expect(f.nativeElement.querySelector('hvi-avatar-stack').getAttribute('tabindex')).toBeNull();
+  });
+
+  it('should have default aria-label "Gruppe med avatarer"', () => {
+    const f = TestBed.createComponent(BasicStackComponent);
+    f.detectChanges();
+    expect(f.nativeElement.querySelector('hvi-avatar-stack').getAttribute('aria-label')).toBe(
+      'Gruppe med avatarer',
+    );
+  });
+
+  it('should allow overriding aria-label', () => {
+    const f = TestBed.createComponent(StackCustomAriaLabelComponent);
+    f.detectChanges();
+    expect(f.nativeElement.querySelector('hvi-avatar-stack').getAttribute('aria-label')).toBe(
+      'Teammedlemmer',
+    );
   });
 
   it('should project avatar children', () => {

--- a/projects/hviktor/src/avatar-stack/avatar-stack.component.ts
+++ b/projects/hviktor/src/avatar-stack/avatar-stack.component.ts
@@ -31,6 +31,8 @@ import { Component, Input } from '@angular/core';
   template: '<ng-content />',
   host: {
     class: 'ds-avatar-stack',
+    role: 'group',
+    '[attr.aria-label]': 'ariaLabel',
     '[attr.data-variant]': 'variant',
     '[attr.data-expandable]': 'expandable',
     '[attr.tabindex]': 'expandable ? "0" : null',
@@ -39,6 +41,9 @@ import { Component, Input } from '@angular/core';
   },
 })
 export class HviAvatarStack {
+  /** Accessible label for the avatar group. Defaults to `'Gruppe med avatarer'`. */
+  @Input('aria-label') ariaLabel: string = 'Gruppe med avatarer';
+
   /** The shape of the stacked avatars (`'square'` or `'circle'`). */
   @Input() variant?: 'square' | 'circle';
 

--- a/src/app/demo/pages/components/avatar-stack/avatar-stack-demo.ts
+++ b/src/app/demo/pages/components/avatar-stack/avatar-stack-demo.ts
@@ -24,7 +24,7 @@ import { AvatarStackStandardAvatarStackExampleSource } from './code-examples/ava
       >
       <app-demo-section title="Standard Avatar Stack" [code]="standardAvatarStackCode">
         <div class="flex flex-wrap gap-2">
-          <hvi-avatar-stack>
+          <hvi-avatar-stack aria-label="Topp 3 ansatte i bedriften">
             <hvi-avatar
               aria-label="Ola Nordmann"
               variant="circle"
@@ -51,7 +51,7 @@ import { AvatarStackStandardAvatarStackExampleSource } from './code-examples/ava
 
       <app-demo-section title="Med suffix" [code]="medSuffixCode">
         <div class="flex flex-wrap gap-2">
-          <hvi-avatar-stack suffix="+4">
+          <hvi-avatar-stack suffix="+4" aria-label="Ansatte i bedriften">
             <hvi-avatar
               aria-label="Ola Nordmann"
               variant="circle"
@@ -78,7 +78,7 @@ import { AvatarStackStandardAvatarStackExampleSource } from './code-examples/ava
 
       <app-demo-section title="Expandable" [code]="expandableCode">
         <div class="flex flex-wrap gap-2">
-          <hvi-avatar-stack expandable="true">
+          <hvi-avatar-stack expandable="true" aria-label="Dine kolleger">
             <hvi-avatar aria-label="Ola Nordmann" variant="circle" color="brand1"></hvi-avatar>
             <hvi-avatar
               aria-label="Kari Nordmann"

--- a/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.expandable.example.source.ts
+++ b/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.expandable.example.source.ts
@@ -8,7 +8,7 @@ import { HviAvatar, HviAvatarStack } from '@helsevestikt/hviktor';
   imports: [HviAvatar, HviAvatarStack],
   template: \`
     <div class="flex flex-wrap gap-2">
-      <hvi-avatar-stack expandable="true">
+      <hvi-avatar-stack expandable="true" aria-label="Dine kolleger">
         <hvi-avatar aria-label="Ola Nordmann" variant="circle" color="brand1"></hvi-avatar>
         <hvi-avatar
           aria-label="Kari Nordmann"

--- a/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.expandable.example.ts
+++ b/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.expandable.example.ts
@@ -7,7 +7,7 @@ import { HviAvatar, HviAvatarStack } from '@helsevestikt/hviktor';
   imports: [HviAvatar, HviAvatarStack],
   template: `
     <div class="flex flex-wrap gap-2">
-      <hvi-avatar-stack expandable="true">
+      <hvi-avatar-stack expandable="true" aria-label="Dine kolleger">
         <hvi-avatar aria-label="Ola Nordmann" variant="circle" color="brand1"></hvi-avatar>
         <hvi-avatar
           aria-label="Kari Nordmann"

--- a/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.med-suffix.example.source.ts
+++ b/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.med-suffix.example.source.ts
@@ -8,7 +8,7 @@ import { HviAvatar, HviAvatarStack } from '@helsevestikt/hviktor';
   imports: [HviAvatar, HviAvatarStack],
   template: \`
     <div class="flex flex-wrap gap-2">
-      <hvi-avatar-stack suffix="+4">
+      <hvi-avatar-stack suffix="+4" aria-label="Ansatte i bedriften">
         <hvi-avatar
           aria-label="Ola Nordmann"
           variant="circle"

--- a/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.med-suffix.example.ts
+++ b/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.med-suffix.example.ts
@@ -7,7 +7,7 @@ import { HviAvatar, HviAvatarStack } from '@helsevestikt/hviktor';
   imports: [HviAvatar, HviAvatarStack],
   template: `
     <div class="flex flex-wrap gap-2">
-      <hvi-avatar-stack suffix="+4">
+      <hvi-avatar-stack suffix="+4" aria-label="Ansatte i bedriften">
         <hvi-avatar
           aria-label="Ola Nordmann"
           variant="circle"

--- a/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.standard-avatar-stack.example.source.ts
+++ b/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.standard-avatar-stack.example.source.ts
@@ -8,7 +8,7 @@ import { HviAvatar, HviAvatarStack } from '@helsevestikt/hviktor';
   imports: [HviAvatar, HviAvatarStack],
   template: \`
     <div class="flex flex-wrap gap-2">
-      <hvi-avatar-stack>
+      <hvi-avatar-stack aria-label="Topp 3 ansatte i bedriften">
         <hvi-avatar
           aria-label="Ola Nordmann"
           variant="circle"

--- a/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.standard-avatar-stack.example.ts
+++ b/src/app/demo/pages/components/avatar-stack/code-examples/avatar-stack.standard-avatar-stack.example.ts
@@ -7,7 +7,7 @@ import { HviAvatar, HviAvatarStack } from '@helsevestikt/hviktor';
   imports: [HviAvatar, HviAvatarStack],
   template: `
     <div class="flex flex-wrap gap-2">
-      <hvi-avatar-stack>
+      <hvi-avatar-stack aria-label="Topp 3 ansatte i bedriften">
         <hvi-avatar
           aria-label="Ola Nordmann"
           variant="circle"


### PR DESCRIPTION
#261 
role="group" er lagt til på AvatarStacken og kommer da alltid med når den brukes. Dette ble anbefalt for bedre UU.
Det er lagt til en standard aria-label på den også, men denne kan og bør overstyres når den brukes med riktig passende beskrivelse der den brukes. Lagt til aria-label som overstyrer den som automatisk kommer med i demoen, slik at utviklerne kan se at de bør skrive en beskrivende aria-label for den, men hvis det blir glemt, så har den aria-label="Gruppe med avatarer" just in case.