### PR TITLE
test(link): add JSDoc, unit tests, and E2E tests

### DIFF
--- a/e2e/components/link.spec.ts
+++ b/e2e/components/link.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { checkAccessibility } from '../fixtures/axe-helper';
+import { ComponentPage } from '../fixtures/component-page';
+
+test.describe('Link', () => {
+  test.beforeEach(async ({ page }) => {
+    const componentPage = new ComponentPage(page);
+    await componentPage.goto('link');
+  });
+
+  test('renders link with ds-link class', async ({ page }) => {
+    const section = page.locator('app-demo-section[title="Varianter"]');
+    await expect(section).toBeVisible();
+
+    const link = section.locator('a.ds-link').first();
+    await expect(link).toBeVisible();
+  });
+
+  test('neutral color variant has data-color="neutral"', async ({ page }) => {
+    const section = page.locator('app-demo-section[title="Varianter"]');
+    await expect(section).toBeVisible();
+
+    const neutralLink = section.locator('a.ds-link[data-color="neutral"]');
+    await expect(neutralLink).toBeVisible();
+    await expect(neutralLink).toHaveAttribute('data-color', 'neutral');
+  });
+
+  test('default link does not emit data-color attribute', async ({ page }) => {
+    const section = page.locator('app-demo-section[title="Varianter"]');
+    await expect(section).toBeVisible();
+
+    const defaultLink = section.locator('a.ds-link:not([data-color])');
+    await expect(defaultLink).toBeVisible();
+  });
+
+  test('accessibility check', async ({ page }) => {
+    await checkAccessibility(page, ['color-contrast'], 'article');
+  });
+});

--- a/projects/hviktor/src/link/index.ts
+++ b/projects/hviktor/src/link/index.ts
@@ -1,1 +1,1 @@
-export * from './link.directive';
+export { HviLink } from './link.directive';

--- a/projects/hviktor/src/link/link.directive.spec.ts
+++ b/projects/hviktor/src/link/link.directive.spec.ts
@@ -1,0 +1,59 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { setupTestBed } from '../testing/test-utils';
+import { HviLink } from './link.directive';
+
+@Component({
+  standalone: true,
+  imports: [HviLink],
+  template: `<a hviLink href="/page">Default link</a>`,
+})
+class DefaultLinkHost {}
+
+@Component({
+  standalone: true,
+  imports: [HviLink],
+  template: `<a hviLink href="/page" color="neutral">Neutral link</a>`,
+})
+class NeutralColorHost {}
+
+@Component({
+  standalone: true,
+  imports: [HviLink],
+  template: `<button hviLink>Button link</button>`,
+})
+class ButtonHost {}
+
+describe('HviLink', () => {
+  beforeEach(async () => {
+    await setupTestBed({ imports: [DefaultLinkHost, NeutralColorHost, ButtonHost] });
+  });
+
+  it('applies ds-link class to anchor element', () => {
+    const fixture = TestBed.createComponent(DefaultLinkHost);
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('a');
+    expect(el.classList.contains('ds-link')).toBe(true);
+  });
+
+  it('does not emit data-color attribute by default', () => {
+    const fixture = TestBed.createComponent(DefaultLinkHost);
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('a');
+    expect(el.getAttribute('data-color')).toBeNull();
+  });
+
+  it('reflects color input as data-color attribute', () => {
+    const fixture = TestBed.createComponent(NeutralColorHost);
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('a');
+    expect(el.getAttribute('data-color')).toBe('neutral');
+  });
+
+  it('applies ds-link class to button element', () => {
+    const fixture = TestBed.createComponent(ButtonHost);
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('button');
+    expect(el.classList.contains('ds-link')).toBe(true);
+  });
+});

--- a/projects/hviktor/src/link/link.directive.ts
+++ b/projects/hviktor/src/link/link.directive.ts
@@ -1,18 +1,27 @@
 import { Directive, Input } from '@angular/core';
 
 /**
- * Info
+ * @summary Directive that applies Designsystemet link styling to anchor or button elements.
  *
- * Eksempel på bruk:
+ * @example Basic link
  * ```html
- * <a hviLink />
+ * <a hviLink href="/page">Go to page</a>
  * ```
  *
- * Dokumentasjon: https://designsystemet.no/no/components/docs/input/overview
+ * @example Neutral color variant
+ * ```html
+ * <a hviLink href="/privacy" color="neutral">Privacy policy</a>
+ * ```
+ *
+ * @example Link styled as button
+ * ```html
+ * <button hviLink (click)="navigate()">Navigate</button>
+ * ```
+ *
+ * @see {@link https://designsystemet.no/no/components/docs/link}
  */
-
 @Directive({
-  selector: 'a[hviLink]',
+  selector: 'a[hviLink], button[hviLink]',
   standalone: true,
   host: {
     class: 'ds-link',
@@ -20,6 +29,6 @@ import { Directive, Input } from '@angular/core';
   },
 })
 export class HviLink {
-  /** Used to change the appearance of the link. */
-  @Input() color?: 'default' | 'neutral' = 'default';
+  /** Color variant for the link. Only `neutral` changes appearance; omit for default styling. */
+  @Input() color?: 'neutral';
 }

--- a/src/app/demo/demo-components.ts
+++ b/src/app/demo/demo-components.ts
@@ -141,6 +141,7 @@ export const DEMO_COMPONENTS: DemoComponent[] = [
       'Link er klikkbar tekst eller grafikk som tar brukeren videre til andre sider eller dokumenter.',
     ds: true,
     a11yTested: true,
+    codeTested: true,
   },
   {
     id: 'list',


### PR DESCRIPTION
- Fix selector to support both anchor and button elements
- Fix color input to only emit data-color for neutral variant
- Update JSDoc with @summary, @example, @see
- Convert index.ts to named export
- Add unit tests (4) and E2E tests (4×3 browsers)
- Set codeTested: true in demo-components